### PR TITLE
Add 2-man Team Scramble scorecard

### DIFF
--- a/client/src/components/TwoManTeamScrambleScorecard.tsx
+++ b/client/src/components/TwoManTeamScrambleScorecard.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useTeams } from "@/hooks/useTeams";
+
+interface HoleScore {
+  holeNumber: number;
+  aviatorScore: number | null;
+  producerScore: number | null;
+}
+
+interface ScorecardProps {
+  holes: { hole_number: number }[];
+  scores: HoleScore[];
+  locked?: boolean;
+  onUpdateScores?: (scores: HoleScore[]) => void;
+}
+
+const TwoManTeamScrambleScorecard: React.FC<ScorecardProps> = ({
+  holes = [],
+  scores = [],
+  locked = false,
+  onUpdateScores,
+}) => {
+  const { data: teams = [] } = useTeams();
+
+  // Helper functions to get team IDs dynamically
+  const getAviatorTeamId = () => {
+    const aviatorTeam = teams.find(team =>
+      team.name.toLowerCase().includes('aviator') ||
+      team.name.toLowerCase().includes('aviators')
+    );
+    return aviatorTeam?.id || 1;
+  };
+
+  const getProducerTeamId = () => {
+    const producerTeam = teams.find(team =>
+      team.name.toLowerCase().includes('producer') ||
+      team.name.toLowerCase().includes('producers')
+    );
+    return producerTeam?.id || 2;
+  };
+
+  const handleScoreChange = (holeIndex: number, team: 'aviator' | 'producer', value: string) => {
+    const newScores = [...scores];
+    const score = parseInt(value, 10);
+    if (!isNaN(score)) {
+      if (team === 'aviator') newScores[holeIndex].aviatorScore = score;
+      else newScores[holeIndex].producerScore = score;
+      onUpdateScores?.(newScores);
+    }
+  };
+
+  // Get team names dynamically
+  const aviatorTeamName = teams.find(team => team.id === getAviatorTeamId())?.name || 'Aviators';
+  const producerTeamName = teams.find(team => team.id === getProducerTeamId())?.name || 'Producers';
+
+  return (
+    <Card className="rounded-2xl shadow p-4">
+      <CardHeader>
+        <CardTitle>2-Man Team Scramble Scorecard</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th>Hole</th>
+              <th>{aviatorTeamName}</th>
+              <th>{producerTeamName}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {holes.map((hole, i) => (
+              <tr key={i} className="border-t">
+                <td className="text-center">{hole.hole_number}</td>
+                <td>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    value={scores[i]?.aviatorScore ?? ''}
+                    disabled={locked}
+                    onChange={(e) => handleScoreChange(i, 'aviator', e.target.value)}
+                  />
+                </td>
+                <td>
+                  <Input
+                    type="number"
+                    className="text-center"
+                    value={scores[i]?.producerScore ?? ''}
+                    disabled={locked}
+                    onChange={(e) => handleScoreChange(i, 'producer', e.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TwoManTeamScrambleScorecard;

--- a/client/src/pages/Match.tsx
+++ b/client/src/pages/Match.tsx
@@ -7,6 +7,7 @@ import EnhancedMatchScorecard from "@/components/EnhancedMatchScorecard";
 import TwoManTeamBestBallScorecard, { transformRawPlayerData } from "@/components/TwoManTeamBestBallScorecard";
 import TwoManTeamGrossScorecard from "@/components/TwoManTeamGrossScorecard";
 import FourManTeamScrambleScorecard from "@/components/FourManTeamScrambleScorecard";
+import TwoManTeamScrambleScorecard from "@/components/TwoManTeamScrambleScorecard";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { ChevronLeft, Edit, Save, Lock, Unlock } from "lucide-react";
@@ -857,6 +858,26 @@ const Match = ({ id }: { id: number }) => {
               locked={isLocked}
             />
           )}
+          {round?.matchType === "2-man Team Scramble" && (
+            <TwoManTeamScrambleScorecard
+              holes={(holes || []).map(hole => ({
+                hole_number: hole.number,
+                par: hole.par,
+                ...(hole.id !== undefined ? { id: hole.id } : {})
+              }))}
+              scores={(scores || []).map(score => ({
+                holeNumber: score.holeNumber,
+                aviatorScore: score.aviatorScore,
+                producerScore: score.producerScore
+              }))}
+              locked={isLocked}
+              onUpdateScores={(updatedScores) => {
+                updatedScores.forEach(score => {
+                  handleScoreUpdate(score.holeNumber, score.aviatorScore, score.producerScore);
+                });
+              }}
+            />
+          )}
           {round?.matchType === "4-man scramble" && (
             <FourManTeamScrambleScorecard
               holes={(holes || []).map(hole => ({
@@ -870,6 +891,11 @@ const Match = ({ id }: { id: number }) => {
                 producerScore: score.producerScore
               }))}
               locked={isLocked}
+              onUpdateScores={(updatedScores) => {
+                updatedScores.forEach(score => {
+                  handleScoreUpdate(score.holeNumber, score.aviatorScore, score.producerScore);
+                });
+              }}
             />
           )}
         </>


### PR DESCRIPTION
This commit introduces a new scorecard component for 2-man team scramble matches.

- Created `TwoManTeamScrambleScorecard.tsx` by adapting the existing `FourManTeamScrambleScorecard.tsx`.
- Updated `Match.tsx` to render the new scorecard when the match type is "2-man Team Scramble".
- Added the `onUpdateScores` prop to the `FourManTeamScrambleScorecard` component in `Match.tsx` for consistency and to enable score updates.