### PR TITLE
Fix: Resolve runtime error in TwoManTeamBestBallScorecard

### DIFF
--- a/client/src/components/TwoManTeamBestBallScorecard.tsx
+++ b/client/src/components/TwoManTeamBestBallScorecard.tsx
@@ -6,7 +6,6 @@ import {
   type HoleInfo,
   type PlayerData,
   type BestBallPlayerScore,
-  updatePlayerCourseHandicap, // This is not a type, it's a function from the hook. Typo in my thought process.
 } from "../hooks/useBestBallScorecardLogic";
 import { useAuth } from "../hooks/use-auth"; // Added import
 import "./TwoManTeamBestBallScorecard.css";


### PR DESCRIPTION
Corrects a runtime error "Missing initializer in destructuring declaration" that occurred in `TwoManTeamBestBallScorecard.tsx`.

The error was caused by an incorrect import of `updatePlayerCourseHandicap` directly from the `../hooks/useBestBallScorecardLogic` module. This function is, and was correctly, obtained from the return value of the `useBestBallScorecardLogic()` hook call within the component.

The erroneous import has been removed, which should resolve the issue with the dependency array of the `renderScoreGrid` callback.