### PR TITLE
Implement team hooks and shamble scoring

### DIFF
--- a/client/src/components/TwoManTeamShambleScorecard.tsx
+++ b/client/src/components/TwoManTeamShambleScorecard.tsx
@@ -16,7 +16,7 @@ interface ScorecardProps {
   onUpdateScores?: (scores: HoleScore[]) => void;
 }
 
-const FourManTeamScrambleScorecard: React.FC<ScorecardProps> = ({
+const TwoManTeamShambleScorecard: React.FC<ScorecardProps> = ({
   holes = [],
   scores = [],
   locked = false,
@@ -39,6 +39,7 @@ const FourManTeamScrambleScorecard: React.FC<ScorecardProps> = ({
     );
     return producerTeam?.id || 2;
   };
+
   const handleScoreChange = (holeIndex: number, team: 'aviator' | 'producer', value: string) => {
     const newScores = [...scores];
     const score = parseInt(value, 10);
@@ -55,7 +56,7 @@ const FourManTeamScrambleScorecard: React.FC<ScorecardProps> = ({
   return (
     <Card className="rounded-2xl shadow p-4">
       <CardHeader>
-        <CardTitle>4-Man Team Scramble Scorecard</CardTitle>
+        <CardTitle>2-Man Team Shamble Scorecard</CardTitle>
       </CardHeader>
       <CardContent>
         <table className="w-full text-sm">
@@ -97,4 +98,4 @@ const FourManTeamScrambleScorecard: React.FC<ScorecardProps> = ({
   );
 };
 
-export default FourManTeamScrambleScorecard;
+export default TwoManTeamShambleScorecard;

--- a/client/src/hooks/useTeams.ts
+++ b/client/src/hooks/useTeams.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { getQueryFn } from "@/lib/queryClient";
+
+export interface Team {
+  id: number;
+  name: string;
+  shortName: string;
+  colorCode: string;
+}
+
+export function useTeams() {
+  return useQuery<Team[], Error>({
+    queryKey: ["/api/teams"],
+    queryFn: getQueryFn({ on401: "throw" }),
+  });
+}
+
+export default useTeams;

--- a/client/src/pages/Match.tsx
+++ b/client/src/pages/Match.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import MatchHeader from "@/components/MatchHeader";
 import TwoManTeamBestBallScorecard, { transformRawPlayerData } from "@/components/TwoManTeamBestBallScorecard";
+import TwoManTeamScrambleScorecard from "@/components/TwoManTeamScrambleScorecard";
+import TwoManTeamShambleScorecard from "@/components/TwoManTeamShambleScorecard";
 import TwoManTeamGrossScorecard from "@/components/TwoManTeamGrossScorecard";
 import FourManTeamScrambleScorecard from "@/components/FourManTeamScrambleScorecard";
 import { apiRequest } from "@/lib/queryClient";
@@ -636,7 +638,37 @@ const Match = ({ id }: { id: number }) => {
               }}
             />
           )}
-          {round?.matchType === "2-man gross" && (
+          {(round?.matchType === "2-man Team Scramble" || round?.matchType === "2-man gross") && (
+            <TwoManTeamScrambleScorecard
+              holes={(holes || []).map(hole => ({
+                hole_number: hole.number,
+                par: hole.par,
+                ...(hole.id !== undefined ? { id: hole.id } : {})
+              }))}
+              scores={(scores || []).map(score => ({
+                holeNumber: score.holeNumber,
+                aviatorScore: score.aviatorScore,
+                producerScore: score.producerScore
+              }))}
+              locked={isLocked}
+            />
+          )}
+          {round?.matchType === "2-man Team Shamble" && (
+            <TwoManTeamShambleScorecard
+              holes={(holes || []).map(hole => ({
+                hole_number: hole.number,
+                par: hole.par,
+                ...(hole.id !== undefined ? { id: hole.id } : {})
+              }))}
+              scores={(scores || []).map(score => ({
+                holeNumber: score.holeNumber,
+                aviatorScore: score.aviatorScore,
+                producerScore: score.producerScore
+              }))}
+              locked={isLocked}
+            />
+          )}
+          {(round?.matchType === "2-man gross") && (
             <TwoManTeamGrossScorecard
               holes={(holes || []).map(hole => ({
                 hole_number: hole.number,
@@ -651,7 +683,7 @@ const Match = ({ id }: { id: number }) => {
               locked={isLocked}
             />
           )}
-          {round?.matchType === "4-man scramble" && (
+          {(round?.matchType === "4-man Team Scramble" || round?.matchType === "4-man scramble") && (
             <FourManTeamScrambleScorecard
               holes={(holes || []).map(hole => ({
                 hole_number: hole.number,


### PR DESCRIPTION
## Summary
- add `useTeams` hook for loading teams
- add TwoManTeamShambleScorecard component
- update FourManTeamScrambleScorecard to use dynamic team names
- integrate new components in Match page for 2-man scramble/shamble and 4-man scramble

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbf442ec08320b5fea64e584bbd1b