### PR TITLE
Add 2v2 shamble scorecard component

### DIFF
--- a/client/src/components/TwoManTeamShambleScorecard.css
+++ b/client/src/components/TwoManTeamShambleScorecard.css
@@ -1,0 +1,400 @@
+/* Two Man Team Best Ball Scorecard - Table-based Layout */
+.scorecard-container {
+  margin: 0;
+  padding: 16px;
+  font-family: var(--font-sans);
+  overflow-x: auto;
+}
+
+.scorecard-table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius);
+  border: 2px solid hsl(var(--border));
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.scorecard-table {
+  width: 100%;
+  min-width: 1200px;
+  border-collapse: collapse;
+  background-color: hsl(var(--background));
+  font-size: 14px;
+}
+
+.scorecard-table th,
+.scorecard-table td {
+  padding: 8px 4px;
+  text-align: center;
+  border-right: 1px solid hsl(var(--border));
+  border-bottom: 1px solid hsl(var(--border));
+  font-weight: 500;
+  min-width: 40px;
+}
+
+/* Headers */
+.player-header,
+.total-header {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-weight: 700;
+  text-align: left;
+  padding-left: 12px;
+  font-size: 12px;
+  min-width: 130px;
+}
+
+.hole-header {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-weight: 700;
+  font-size: 12px;
+  padding: 4px;
+}
+
+.hole-number {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.hole-handicap {
+  font-size: 10px;
+  color: hsl(var(--muted-foreground));
+  margin-top: 2px;
+}
+
+/* Player rows */
+.player-row {
+  background-color: hsl(var(--background));
+}
+
+.player-name {
+  text-align: left;
+  padding-left: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 13px;
+  min-width: 130px;
+}
+
+.score-cell {
+  position: relative;
+  padding: 2px;
+  background-color: hsl(var(--background));
+}
+
+.score-input {
+  width: 100%;
+  height: 32px;
+  border: 1px solid hsl(var(--border));
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+  background: transparent;
+  outline: none;
+  border-radius: 4px;
+}
+
+.score-input:focus {
+  background-color: rgba(59, 130, 246, 0.1);
+  outline: 2px solid #3b82f6;
+  border-color: #3b82f6;
+}
+
+.score-display {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.total-cell {
+  font-weight: 700;
+  background-color: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  font-size: 14px;
+}
+
+/* Team rows */
+.team-row {
+  background-color: hsl(var(--accent));
+  font-weight: 700;
+}
+
+.team-name {
+  text-align: left;
+  padding-left: 12px;
+  font-weight: 700;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: hsl(var(--accent-foreground));
+}
+
+.team-score-cell {
+  font-weight: 700;
+  color: hsl(var(--accent-foreground));
+  background-color: hsl(var(--accent));
+}
+
+.team-total-cell {
+  font-weight: 700;
+  background-color: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  font-size: 14px;
+}
+
+/* Match status */
+.match-status {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background-color: hsl(var(--muted));
+  text-align: center;
+}
+
+.match-status h3 {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: hsl(var(--foreground));
+}
+
+.match-status p {
+  margin: 4px 0;
+  font-size: 14px;
+  color: hsl(var(--muted-foreground));
+}
+
+.score-details {
+  margin-top: 8px;
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.score-details p {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+/* Team color variations for player names */
+.player-name.aviator {
+  color: var(--aviator-text);
+  background-color: rgba(59, 130, 246, 0.05);
+  border-left: 4px solid var(--aviator-accent);
+}
+
+.player-name.producer {
+  color: var(--producer-text);
+  background-color: rgba(239, 68, 68, 0.05);
+  border-left: 4px solid var(--producer-accent);
+}
+
+/* Best score highlighting */
+.score-cell.best-score {
+  background-color: rgba(34, 197, 94, 0.15);
+  border: 2px solid rgba(34, 197, 94, 0.4);
+}
+
+.score-cell.best-score .score-input {
+  font-weight: 700;
+  color: #059669;
+}
+
+/* Team total variations */
+.team-total-cell.aviators {
+  background-color: var(--aviator-accent);
+  color: white;
+}
+
+.team-total-cell.producers {
+  background-color: var(--producer-accent);
+  color: white;
+}
+
+/* CSS Variables for team colors */
+:root {
+  --aviator-bg: #dbeafe;
+  --aviator-text: #1e3a8a;
+  --aviator-accent: #3b82f6;
+  
+  --producer-bg: #fee2e2;
+  --producer-text: #7f1d1d;
+  --producer-accent: #ef4444;
+}
+
+/* Mobile responsive styles for table layout */
+@media (max-width: 1024px) {
+  .scorecard-container {
+    padding: 8px;
+  }
+  
+  .scorecard-table {
+    font-size: 12px;
+    min-width: 1000px;
+  }
+  
+  .scorecard-table th,
+  .scorecard-table td {
+    padding: 6px 3px;
+    min-width: 35px;
+  }
+
+  .player-header,
+  .total-header,
+  .player-name {
+    font-size: 11px;
+    padding-left: 8px;
+    min-width: 100px;
+  }
+
+  .score-input {
+    font-size: 12px;
+    height: 28px;
+  }
+  
+  .hole-number {
+    font-size: 11px;
+  }
+  
+  .hole-handicap {
+    font-size: 9px;
+  }
+}
+
+@media (max-width: 768px) {
+  .scorecard-container {
+    padding: 4px;
+  }
+  
+  .scorecard-table {
+    font-size: 11px;
+    min-width: 900px;
+  }
+  
+  .scorecard-table th,
+  .scorecard-table td {
+    padding: 4px 2px;
+    min-width: 30px;
+  }
+
+  .player-header,
+  .total-header,
+  .player-name {
+    font-size: 10px;
+    padding-left: 6px;
+    min-width: 90px;
+  }
+
+  .score-input {
+    font-size: 11px;
+    height: 24px;
+  }
+  
+  .hole-number {
+    font-size: 10px;
+  }
+  
+  .hole-handicap {
+    font-size: 8px;
+  }
+  
+  .net-score {
+    font-size: 8px;
+  }
+  
+  .match-status {
+    padding: 12px;
+    margin-top: 12px;
+  }
+  
+  .match-status h3 {
+    font-size: 14px;
+  }
+  
+  .match-status p {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .scorecard-container {
+    padding: 2px;
+  }
+  
+  .scorecard-table {
+    font-size: 10px;
+    min-width: 800px;
+  }
+  
+  .scorecard-table th,
+  .scorecard-table td {
+    padding: 3px 1px;
+    min-width: 25px;
+  }
+
+  .player-header,
+  .total-header,
+  .player-name {
+    font-size: 9px;
+    padding-left: 4px;
+    min-width: 80px;
+  }
+
+  .score-input {
+    font-size: 10px;
+    height: 22px;
+  }
+  
+  .hole-number {
+    font-size: 9px;
+  }
+  
+  .hole-handicap {
+    font-size: 7px;
+  }
+  
+  .total-cell,
+  .team-total-cell {
+    font-size: 10px;
+  }
+  
+  .match-status {
+    padding: 8px;
+    margin-top: 8px;
+  }
+  
+  .match-status h3 {
+    font-size: 12px;
+  }
+  
+  .match-status p {
+    font-size: 10px;
+  }
+  
+  .score-details {
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
+/* Scrollbar styling for horizontal scroll */
+.scorecard-table-wrapper::-webkit-scrollbar {
+  height: 8px;
+}
+
+.scorecard-table-wrapper::-webkit-scrollbar-track {
+  background: hsl(var(--muted));
+  border-radius: 4px;
+}
+
+.scorecard-table-wrapper::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
+  border-radius: 4px;
+}
+
+.scorecard-table-wrapper::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground));
+}

--- a/client/src/components/TwoManTeamShambleScorecard.tsx
+++ b/client/src/components/TwoManTeamShambleScorecard.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useMemo, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { 
+  useBestBallScorecardLogic,
+  type HoleInfo,
+  type PlayerData,
+  type BestBallPlayerScore,
+} from "../hooks/useBestBallScorecardLogic";
+import { useAuth } from "../hooks/use-auth"; // Added import
+import "./TwoManTeamShambleScorecard.css";
+
+interface RawPlayerData {
+  id: number;
+  name: string;
+  team: 'aviator' | 'producer';
+  handicapStrokes: number[];
+}
+
+export function transformRawPlayerData(
+  rawPlayers: RawPlayerData[],
+  holes: HoleInfo[]
+): PlayerData[] {
+  return rawPlayers.map((p) => ({
+    id: p.id,
+    name: p.name,
+    team: p.team,
+    courseHandicap: p.handicapStrokes ? p.handicapStrokes.reduce((a, b) => a + b, 0) : 0,
+  }));
+}
+
+interface ScorecardProps {
+  roundId: number;
+  courseId: number;
+  holes: HoleInfo[];
+  playerScores?: BestBallPlayerScore[];
+  players?: PlayerData[];
+  locked?: boolean;
+  onUpdateScores?: (playerScores: BestBallPlayerScore[]) => void;
+  onPlayerHandicapChange?: (playerId: number, newHandicap: number, roundId: number, courseId: number) => void; // Added prop
+}
+
+const TwoManTeamShambleScorecard: React.FC<ScorecardProps> = ({
+  roundId,
+  courseId,
+  holes = [],
+  players = [],
+  locked = false,
+  onUpdateScores,
+  onPlayerHandicapChange, // Destructured prop
+}) => {
+  const { isAdmin } = useAuth(); // Get isAdmin status
+
+  // Initialize the hook with provided data
+  const {
+    playerScores: hookPlayerScores,
+    updateScore,
+    updatePlayerCourseHandicap, // Get function from hook
+    aviatorTotals,
+    producerTotals,
+    matchStatus,
+    setPlayers,
+    setHoles,
+  } = useBestBallScorecardLogic({
+    initialPlayers: players,
+    initialHoles: holes,
+  });
+
+  // Update hook state when props change
+  useEffect(() => {
+    if (players.length > 0) {
+      setPlayers(players);
+    }
+  }, [players, setPlayers]);
+
+  useEffect(() => {
+    if (holes.length > 0) {
+      setHoles(holes);
+    }
+  }, [holes, setHoles]);
+
+  // Notify parent of score changes
+  useEffect(() => {
+    if (onUpdateScores && hookPlayerScores.length > 0) {
+      onUpdateScores(hookPlayerScores);
+    }
+  }, [hookPlayerScores, onUpdateScores]);
+
+  const handleScoreChange = useCallback((playerId: number, holeIndex: number, value: string) => {
+    const score = value === '' ? null : parseInt(value, 10);
+    if (value === '' || (!isNaN(score!) && score! >= 1 && score! <= 15)) {
+      if (score !== null) {
+        updateScore(playerId, holeIndex + 1, score); // Hook expects 1-based hole numbers
+      }
+    }
+  }, [updateScore]);
+
+  // Split holes into front nine (1-9) and back nine (10-18)
+  const frontNine = useMemo(() => holes.slice(0, 9), [holes]);
+  const backNine = useMemo(() => holes.slice(9, 18), [holes]);
+
+  const renderScoreGrid = useCallback(() => {
+    // Split holes into front nine (1-9) and back nine (10-18)
+    const frontNine = holes.slice(0, 9);
+    const backNine = holes.slice(9, 18);
+
+    const renderHoleHeader = (hole: HoleInfo) => (
+      <th key={`hole-${hole.hole_number}`} className="hole-header">
+        <div className="hole-number">{hole.hole_number}</div>
+        <div className="hole-handicap">{hole.handicap}</div>
+      </th>
+    );
+
+    const renderPlayerRow = (player: PlayerData, scoreData: BestBallPlayerScore | undefined) => {
+      const scores = scoreData?.scores || [];
+      
+      return (
+        <tr key={`player-${player.id}`} className="player-row">
+          <td className="player-name">{player.name}</td>
+          {holes.map((hole, holeIndex) => {
+            const score = scores[holeIndex] || null;
+            return (
+              <td key={`score-${player.id}-${hole.hole_number}`} className="score-cell">
+                {locked ? (
+                  <span className="score-display">{score || '-'}</span>
+                ) : (
+                  <Input
+                    type="number"
+                    min="1"
+                    max="15"
+                    value={score || ''}
+                    onChange={(e) => handleScoreChange(player.id, holeIndex, e.target.value)}
+                    className="score-input"
+                    placeholder="-"
+                  />
+                )}
+              </td>
+            );
+          })}
+          <td className="total-cell">
+            {scoreData ? scoreData.scores.filter(s => s !== null).reduce((sum, s) => sum + (s || 0), 0) : 0}
+          </td>
+        </tr>
+      );
+    };
+
+    const renderTeamBestBallRow = (teamName: string, teamTotals: { frontTotal: number; backTotal: number; total: number }) => (
+      <tr key={`team-${teamName}`} className="team-row">
+        <td className="team-name">{teamName} Shamble</td>
+        {holes.map((hole, holeIndex) => {
+          // Get the best ball score for this hole from the team's player scores
+          const teamPlayerScores = hookPlayerScores
+            .filter(ps => ps.team === (teamName.toLowerCase() as 'aviator' | 'producer'))
+            .map(ps => ps.scores[holeIndex])
+            .filter(score => score !== null && score !== undefined) as number[];
+          
+          const bestScore = teamPlayerScores.length > 0 ? Math.min(...teamPlayerScores) : null;
+          
+          return (
+            <td key={`team-${teamName}-${holeIndex}`} className="team-score-cell">
+              {bestScore || '-'}
+            </td>
+          );
+        })}
+        <td className="team-total-cell">
+          {teamTotals.total}
+        </td>
+      </tr>
+    );
+
+    const aviatorPlayers = hookPlayerScores.filter(p => p.team === 'aviator');
+    const producerPlayers = hookPlayerScores.filter(p => p.team === 'producer');
+
+    return (
+      <div className="scorecard-container">
+        <div className="scorecard-table-wrapper">
+          <table className="scorecard-table">
+            <thead>
+              <tr>
+                <th className="player-header">Player</th>
+                {holes.map(renderHoleHeader)}
+                <th className="total-header">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {/* Aviator Team */}
+              {aviatorPlayers.map(playerScore => {
+                const player = players.find(p => p.id === playerScore.playerId);
+                return player ? renderPlayerRow(player, playerScore) : null;
+              })}
+              {aviatorTotals && renderTeamBestBallRow('Aviator', aviatorTotals)}
+              
+              {/* Producer Team */}
+              {producerPlayers.map(playerScore => {
+                const player = players.find(p => p.id === playerScore.playerId);
+                return player ? renderPlayerRow(player, playerScore) : null;
+              })}
+              {producerTotals && renderTeamBestBallRow('Producer', producerTotals)}
+            </tbody>
+          </table>
+        </div>
+        
+        {matchStatus && (
+          <div className="match-status">
+            <h3>Match Status</h3>
+            <p>{matchStatus.status}</p>
+            <div className="score-details">
+              <p>Aviator Score: {matchStatus.aviatorScore}</p>
+              <p>Producer Score: {matchStatus.producerScore}</p>
+              <p>Holes Played: {matchStatus.holesPlayed}</p>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }, [holes, players, hookPlayerScores, aviatorTotals, producerTotals, matchStatus, locked, handleScoreChange]);
+
+  return (
+    <Card className="rounded-2xl shadow-lg">
+      <CardHeader>
+        <CardTitle className="text-xl font-bold text-center">2-Man Team Shamble Scorecard</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {hookPlayerScores.length === 0 ? (
+          <div className="p-8 text-center text-muted-foreground">
+            No players found for this match. Please add players to the match first.
+          </div>
+        ) : (
+          renderScoreGrid()
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TwoManTeamShambleScorecard;

--- a/client/src/pages/Match.tsx
+++ b/client/src/pages/Match.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import MatchHeader from "@/components/MatchHeader";
 import TwoManTeamBestBallScorecard, { transformRawPlayerData } from "@/components/TwoManTeamBestBallScorecard";
+import TwoManTeamShambleScorecard from "@/components/TwoManTeamShambleScorecard";
 import TwoManTeamGrossScorecard from "@/components/TwoManTeamGrossScorecard";
 import FourManTeamScrambleScorecard from "@/components/FourManTeamScrambleScorecard";
 import { apiRequest } from "@/lib/queryClient";
@@ -634,6 +635,28 @@ const Match = ({ id }: { id: number }) => {
                 // Convert player scores to the expected ScoreData format for the API
                 console.log('Player scores updated:', playerScores);
               }}
+            />
+          )}
+          {round?.matchType === "2-man Team Shamble" && (
+            <TwoManTeamShambleScorecard
+              roundId={match?.roundId || 0}
+              courseId={round?.courseId || 0}
+              holes={(holes || []).map(hole => ({
+                hole_number: hole.number,
+                par: hole.par,
+                handicap: (hole as any).handicapRank || 1,
+                ...(hole.id !== undefined ? { id: hole.id } : {})
+              }))}
+              players={(participants || []).map(p => {
+                const player = players.find(player => player.id === p.playerId);
+                return {
+                  id: p.playerId,
+                  name: player?.name || `Player ${p.playerId}`,
+                  team: (p.team === 'aviators' ? 'aviator' : 'producer') as 'aviator' | 'producer',
+                  courseHandicap: 0
+                };
+              }).filter(p => p.name !== `Player ${p.id}`)}
+              locked={isLocked}
             />
           )}
           {round?.matchType === "2-man gross" && (


### PR DESCRIPTION
## Summary
- create `TwoManTeamShambleScorecard` component based on best‑ball logic
- show the new scorecard for `2-man Team Shamble` matches

## Testing
- `npm test` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683fc6443e98832088032ca2143e5737